### PR TITLE
Add .tilt files to fileType

### DIFF
--- a/Syntaxes/Tiltfile.tmLanguage
+++ b/Syntaxes/Tiltfile.tmLanguage
@@ -6,6 +6,7 @@
 		<array>
 			<string>Tiltfile</string>
 			<string>tiltfile</string>
+			<string>tilt</string>
 		</array>
 		<key>name</key>
 		<string>Tiltfile</string>


### PR DESCRIPTION
The plugin only finds files called 'Tiltfile' or 'tiltfile', and not files ending with '.tilt'. This adds .tilt files to the filetypes list.

Tested manually by adding the tmtundle to my local IntelliJ and opening a .tilt file.